### PR TITLE
Feat/persist dropdown selections

### DIFF
--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -531,19 +531,44 @@
     const presetSelect = document.getElementById('date-preset');
     const customContainer = document.getElementById('custom-date-container');
     const weekdayPickerContainer = document.getElementById('weekday-picker-container');
+    const dateFromInput = document.getElementById('date-from');
+    const dateToInput = document.getElementById('date-to');
+    const weekdaySelect = document.getElementById('weekday-select');
+
+    const savedPreset = localStorage.getItem('sp-dashboard-date-preset');
+    if (savedPreset) {
+      presetSelect.value = savedPreset;
+      customContainer.classList.toggle('hidden', savedPreset !== 'custom');
+      weekdayPickerContainer.classList.toggle('hidden', savedPreset !== 'from-weekday');
+      const savedFrom = localStorage.getItem('sp-dashboard-date-from');
+      const savedTo = localStorage.getItem('sp-dashboard-date-to');
+      if (savedPreset === 'custom' && savedFrom) dateFromInput.value = savedFrom;
+      if (savedPreset === 'custom' && savedTo) dateToInput.value = savedTo;
+      const savedWeekday = localStorage.getItem('sp-dashboard-weekday-select');
+      if (savedPreset === 'from-weekday' && savedWeekday) weekdaySelect.value = savedWeekday;
+    }
 
     presetSelect.addEventListener('change', (e) => {
       customContainer.classList.toggle('hidden', e.target.value !== 'custom');
       weekdayPickerContainer.classList.toggle('hidden', e.target.value !== 'from-weekday');
+      localStorage.setItem('sp-dashboard-date-preset', e.target.value);
       processData(cachedTasks, cachedProjects);
     });
 
-    document.getElementById('weekday-select').addEventListener('change', () => processData(cachedTasks, cachedProjects));
+    weekdaySelect.addEventListener('change', () => { localStorage.setItem('sp-dashboard-weekday-select', weekdaySelect.value); processData(cachedTasks, cachedProjects); });
 
-    document.getElementById('date-from').addEventListener('change', () => processData(cachedTasks, cachedProjects));
-    document.getElementById('date-to').addEventListener('change', () => processData(cachedTasks, cachedProjects));
-    document.getElementById('bar-chart-select').addEventListener('change', () => updateBarChart());
-    document.getElementById('pie-chart-select').addEventListener('change', () => updatePieChart());
+    dateFromInput.addEventListener('change', () => { localStorage.setItem('sp-dashboard-date-from', dateFromInput.value); processData(cachedTasks, cachedProjects); });
+    dateToInput.addEventListener('change', () => { localStorage.setItem('sp-dashboard-date-to', dateToInput.value); processData(cachedTasks, cachedProjects); });
+    const barChartSelect = document.getElementById('bar-chart-select');
+    const pieChartSelect = document.getElementById('pie-chart-select');
+
+    const savedBar = localStorage.getItem('sp-dashboard-bar-chart-select');
+    const savedPie = localStorage.getItem('sp-dashboard-pie-chart-select');
+    if (savedBar) barChartSelect.value = savedBar;
+    if (savedPie) pieChartSelect.value = savedPie;
+
+    barChartSelect.addEventListener('change', () => { localStorage.setItem('sp-dashboard-bar-chart-select', barChartSelect.value); updateBarChart(); });
+    pieChartSelect.addEventListener('change', () => { localStorage.setItem('sp-dashboard-pie-chart-select', pieChartSelect.value); updatePieChart(); });
 
     // --- RENDER LOGIC ---
     const updateDashboardUI = (metrics) => {

--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -269,6 +269,19 @@
             <option value="month">Past Month</option>
             <option value="year">Past Year</option>
             <option value="custom">Custom Range...</option>
+            <option value="from-weekday">Starting from weekday</option>
+          </select>
+        </div>
+        <div id="weekday-picker-container" class="control-box hidden">
+          <label for="weekday-select">Weekday</label>
+          <select id="weekday-select">
+            <option value="1">Monday</option>
+            <option value="2">Tuesday</option>
+            <option value="3">Wednesday</option>
+            <option value="4">Thursday</option>
+            <option value="5">Friday</option>
+            <option value="6">Saturday</option>
+            <option value="0">Sunday</option>
           </select>
         </div>
       </div>
@@ -517,15 +530,15 @@
 
     const presetSelect = document.getElementById('date-preset');
     const customContainer = document.getElementById('custom-date-container');
+    const weekdayPickerContainer = document.getElementById('weekday-picker-container');
 
     presetSelect.addEventListener('change', (e) => {
-      if (e.target.value === 'custom') {
-        customContainer.classList.remove('hidden');
-      } else {
-        customContainer.classList.add('hidden');
-      }
+      customContainer.classList.toggle('hidden', e.target.value !== 'custom');
+      weekdayPickerContainer.classList.toggle('hidden', e.target.value !== 'from-weekday');
       processData(cachedTasks, cachedProjects);
     });
+
+    document.getElementById('weekday-select').addEventListener('change', () => processData(cachedTasks, cachedProjects));
 
     document.getElementById('date-from').addEventListener('change', () => processData(cachedTasks, cachedProjects));
     document.getElementById('date-to').addEventListener('change', () => processData(cachedTasks, cachedProjects));
@@ -763,6 +776,10 @@
           startObj.setMonth(endObj.getMonth() - 1);
         } else if (preset === 'year') {
           startObj.setFullYear(endObj.getFullYear() - 1);
+        } else if (preset === 'from-weekday') {
+          const targetDay = parseInt(document.getElementById('weekday-select').value, 10);
+          const daysBack = (endObj.getDay() - targetDay + 7) % 7;
+          startObj.setDate(endObj.getDate() - daysBack);
         }
         dateFromStr = startObj.toISOString().split('T')[0];
         dateToStr = endObj.toISOString().split('T')[0];

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -364,6 +364,33 @@ describe('Date Range Reporter UI', () => {
       expect(pieLegend.querySelector('.legend-item')).not.toBeNull();
     });
 
+    it('from-weekday preset with weekday picker should produce correct date range', () => {
+      const presetSelect = document.getElementById('date-preset');
+      const weekdaySelect = document.getElementById('weekday-select');
+      const barContainer = document.getElementById('bar-chart-container');
+      const weekdayPickerContainer = document.getElementById('weekday-picker-container');
+
+      presetSelect.value = 'from-weekday';
+      presetSelect.dispatchEvent(new Event('change'));
+      expect(weekdayPickerContainer.classList.contains('hidden')).toBe(false);
+
+      // Test each weekday
+      const today = new Date();
+      for (const targetDay of [0, 1, 2, 3, 4, 5, 6]) {
+        weekdaySelect.value = String(targetDay);
+        weekdaySelect.dispatchEvent(new Event('change'));
+        window.processData([], []);
+
+        const daysBack = (today.getDay() - targetDay + 7) % 7;
+        expect(barContainer.querySelectorAll('.bar-col').length).toBe(daysBack + 1);
+      }
+
+      // Switching away hides the picker
+      presetSelect.value = 'today';
+      presetSelect.dispatchEvent(new Event('change'));
+      expect(weekdayPickerContainer.classList.contains('hidden')).toBe(true);
+    });
+
     it('detail list columns are sortable when headers are clicked', () => {
       // create two tasks with different dates
       const taskA = { id:'a', parentId:null, title:'A', isDone:false, dueDay:'2026-01-01', timeSpentOnDay:{'2026-01-01':3600000} };


### PR DESCRIPTION
## Summary                                                        
                                         
  Persists chart dropdown selections and date range preset across   
  sessions using `localStorage`, so user preferences are restored on
   next load.                                                       
                                                            
  ## Changes

  - `index.html` — save/restore bar chart, pie chart, date preset,  
  custom date range, and weekday picker selections

Observe that here I am pulling two features, the one already present in #10 and the described one.